### PR TITLE
[Feat] Add single toggle hotkey

### DIFF
--- a/src/action_process.zsh
+++ b/src/action_process.zsh
@@ -124,7 +124,7 @@ handle_deactivation() {
 }
 
 main() {
-    local INPUT="${hotkey_value:-$1}"
+    local INPUT="$1"
 
     [[ -z "$INPUT" || "$INPUT" == "0" ]] && exit 0 # Exit silently for invalid/empty input
 
@@ -138,7 +138,7 @@ main() {
         TIME:*)
             handle_target_time "$INPUT"
             ;;
-        [0-9]*)
+        [1-9]*)
             [[ "$INPUT" =~ ^[0-9]+$ ]] && handle_duration "$INPUT" || {
                 echo "Error: Invalid input format: $INPUT" >&2
                 exit 1

--- a/src/toggle_hotkey.zsh
+++ b/src/toggle_hotkey.zsh
@@ -1,0 +1,16 @@
+#!/bin/zsh --no-rcs
+
+allow_sleep="false"
+case "${hotkey_allow_sleep:l}" in
+    true|1|yes|on)
+        allow_sleep="true"
+        ;;
+esac
+
+STATE=$(osascript -e 'tell application "Amphetamine" to return session is active' 2>/dev/null)
+
+if [[ "$STATE" == "true" ]]; then
+    echo "{\"alfredworkflow\":{\"arg\":\"deactivate\",\"variables\":{\"display_sleep_allow\":\"$allow_sleep\"}}}"
+else
+    echo "{\"alfredworkflow\":{\"arg\":\"indefinite\",\"variables\":{\"display_sleep_allow\":\"$allow_sleep\"}}}"
+fi


### PR DESCRIPTION
Implements a single hotkey to quickly toggle Amphetamine on and off, based on #3.

Added `src/action_process.zsh`, which checks Amphetamine's current status and determines whether to start or end a session.

Added a checkbox in the workflow settings to configure the hotkey's "Allow display sleep" behavior.